### PR TITLE
OPENIDM-18263 - disappearing attribute values

### DIFF
--- a/src/components/access/RelationshipEdit.vue
+++ b/src/components/access/RelationshipEdit.vue
@@ -261,7 +261,7 @@ export default {
 
                 this.setValue(this.relationshipProperty.key, { _ref: selected.value });
             } else {
-                this.selected = null;
+                this.selected = this.selected ? this.selected : null;
                 this.setValue(this.relationshipProperty.key, null);
             }
         }


### PR DESCRIPTION
The existing behavior is correct due to the limitations of the multiselect library in use. However I have now changed too the new behavior: 

If the value has NOT changed then retain the existing value,
Otherwise, change the value, or if null set it to null.

**Previously**
Change the value to null to allow searching, **not a bug**

Only affects select list AKA [Multiselect](https://vue-multiselect.js.org/)